### PR TITLE
shelter ui indicator update, active ui tab

### DIFF
--- a/Assets/WorkPlace/LHG/Scenes/Don'tTouch(EventTab).unity
+++ b/Assets/WorkPlace/LHG/Scenes/Don'tTouch(EventTab).unity
@@ -874,7 +874,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.00002341535}
+  m_AnchoredPosition: {x: 0, y: -0.000043941327}
   m_SizeDelta: {x: 0, y: 392.18}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &83923390
@@ -10567,7 +10567,7 @@ MonoBehaviour:
   eventButtonPrefab: {fileID: 1576431746535964494, guid: 5632298244e6ee945b8709a6bfb83b98,
     type: 3}
   eventUI: {fileID: 1708774638}
-  testItem: {fileID: 11400000, guid: d84ca822bfa17b0428dcfc97b3e00c8c, type: 2}
+  testItem: {fileID: 11400000, guid: 3a5f26ef8db564045b084fb7dfd08f27, type: 2}
 --- !u!4 &1079479337
 Transform:
   m_ObjectHideFlags: 0
@@ -13720,12 +13720,12 @@ PrefabInstance:
     - target: {fileID: 1080031413479747586, guid: a0eee75762c05aa4cada9e222cc8d4f7,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1080031413479747586, guid: a0eee75762c05aa4cada9e222cc8d4f7,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2194442513174379763, guid: a0eee75762c05aa4cada9e222cc8d4f7,
         type: 3}
@@ -13857,12 +13857,12 @@ PrefabInstance:
     - target: {fileID: 7591662803329607802, guid: a0eee75762c05aa4cada9e222cc8d4f7,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: -3
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7591662803329607802, guid: a0eee75762c05aa4cada9e222cc8d4f7,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 60
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8132896701983147723, guid: a0eee75762c05aa4cada9e222cc8d4f7,
         type: 3}
@@ -15884,19 +15884,13 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 142}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &1663529904 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7364306310976251414, guid: 58e651541d52ee44cb0e2bf2a31e9673,
-    type: 3}
-  m_PrefabInstance: {fileID: 1014438738282105238}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1663529906 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1296763153901753342, guid: 58e651541d52ee44cb0e2bf2a31e9673,
     type: 3}
   m_PrefabInstance: {fileID: 1014438738282105238}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1663529904}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
@@ -16245,7 +16239,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.000030517578, y: 0.000021881428}
+  m_AnchoredPosition: {x: 0.000030517578, y: -0.000027280968}
   m_SizeDelta: {x: 0, y: 463}
   m_Pivot: {x: 0, y: 1}
 --- !u!1 &1696008369
@@ -16417,10 +16411,6 @@ MonoBehaviour:
   EventContainer:
   - {fileID: 643968331}
   - {fileID: 0}
-  CompleteBtn:
-  - {fileID: 1663529904}
-  - {fileID: 1714973337}
-  - {fileID: 1885312256}
   MapLocations:
   - {fileID: 67412301}
   - {fileID: 503735093}
@@ -16451,7 +16441,6 @@ MonoBehaviour:
   - {fileID: 1463208941}
   InactiveTabBG: {fileID: 21300000, guid: fd8878743e74b6e49b8b148d485f3566, type: 3}
   ActiveTabBG: {fileID: 21300000, guid: 37ea3d83eeaba3044b90ba681d1945b1, type: 3}
-  testState: 0
   testOxygen: 0
   Renpy: {fileID: 977143772}
 --- !u!114 &1708774638
@@ -16474,19 +16463,13 @@ MonoBehaviour:
   mainUIEventEffectName: {fileID: 1438539952}
   mainUIEEventRequireItemName: {fileID: 1886892189}
   EventListContent: []
---- !u!1 &1714973337 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6477649129409888911, guid: 58e651541d52ee44cb0e2bf2a31e9673,
-    type: 3}
-  m_PrefabInstance: {fileID: 1014438738282105238}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1714973339 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2154058455266177910, guid: 58e651541d52ee44cb0e2bf2a31e9673,
     type: 3}
   m_PrefabInstance: {fileID: 1014438738282105238}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1714973337}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
@@ -17761,19 +17744,13 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1882791561}
   m_CullTransparentMesh: 1
---- !u!1 &1885312256 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3676303117905750728, guid: 58e651541d52ee44cb0e2bf2a31e9673,
-    type: 3}
-  m_PrefabInstance: {fileID: 1014438738282105238}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1885312258 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7301636926692883697, guid: 58e651541d52ee44cb0e2bf2a31e9673,
     type: 3}
   m_PrefabInstance: {fileID: 1014438738282105238}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1885312256}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
@@ -17946,7 +17923,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1903160399
 RectTransform:
   m_ObjectHideFlags: 0
@@ -19988,9 +19965,34 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2154058455266177910, guid: 58e651541d52ee44cb0e2bf2a31e9673,
         type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2154058455266177910, guid: 58e651541d52ee44cb0e2bf2a31e9673,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2154058455266177910, guid: 58e651541d52ee44cb0e2bf2a31e9673,
+        type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 1708774637}
+      objectReference: {fileID: 1708774638}
+    - target: {fileID: 2154058455266177910, guid: 58e651541d52ee44cb0e2bf2a31e9673,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2154058455266177910, guid: 58e651541d52ee44cb0e2bf2a31e9673,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: EventUI, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 2154058455266177910, guid: 58e651541d52ee44cb0e2bf2a31e9673,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: GameEventData, Assembly-CSharp
+      objectReference: {fileID: 0}
     - target: {fileID: 2915791672776112023, guid: 58e651541d52ee44cb0e2bf2a31e9673,
         type: 3}
       propertyPath: m_fontAsset

--- a/Assets/WorkPlace/LHG/Scripts/EventSystem/EventManager.cs
+++ b/Assets/WorkPlace/LHG/Scripts/EventSystem/EventManager.cs
@@ -22,8 +22,8 @@ public class EventManager : MonoBehaviour
     [SerializeField] private EventUI eventUI;
 
 
-    //참조연결 지붕조각 연결하기 **테스트용코드 반드시 삭제**
-    [SerializeField] Item testItem;
+    ////참조연결 지붕조각 연결하기 **테스트용코드 반드시 삭제**
+    //[SerializeField] Item testItem;
 
     private void Awake()
     {
@@ -45,17 +45,17 @@ public class EventManager : MonoBehaviour
         EventStart();
     }
 
-    private void Update()
-    {
-        //**테스트용 코드 반드시 삭제**
-        if (Input.GetKeyDown(KeyCode.H))
-        {
+    //private void Update()
+    //{
+    //    //**테스트용 코드 반드시 삭제**
+    //    if (Input.GetKeyDown(KeyCode.H))
+    //    {
 
-            Storage.Instance.AddItemToStorage(testItem, 1);
-            Debug.Log($"{testItem.name}창고에 추가됨");
-        }
-        //**테스트용 코드 반드시 삭제**
-    }
+    //        Storage.Instance.AddItemToStorage(testItem, 1);
+    //        Debug.Log($"{testItem.name}창고에 추가됨");
+    //    }
+    //    //**테스트용 코드 반드시 삭제**
+    //}
 
     private void InitializeCurrentDay()
     {

--- a/Assets/WorkPlace/LHG/Scripts/EventSystem/EventManager.cs
+++ b/Assets/WorkPlace/LHG/Scripts/EventSystem/EventManager.cs
@@ -13,7 +13,6 @@ public class EventManager : MonoBehaviour
     private Dictionary<int, GameEventData> eventDict = new();
     private int _curGameDay;
     private GameEventData _curEventData;
-    public GameEventData CurEventData { get { return _curEventData; } } //무슨용도?
 
     public List<GameEventData> CurEvents = new(); 
     public List<Button> CurEventButtons = new(); 
@@ -23,7 +22,7 @@ public class EventManager : MonoBehaviour
     [SerializeField] private EventUI eventUI;
 
 
-    //참조연결 지붕조각 연결하기
+    //참조연결 지붕조각 연결하기 **테스트용코드 반드시 삭제**
     [SerializeField] Item testItem;
 
     private void Awake()
@@ -44,10 +43,17 @@ public class EventManager : MonoBehaviour
     private void Start()
     {
         EventStart();
+    }
 
+    private void Update()
+    {
         //**테스트용 코드 반드시 삭제**
-        Storage.Instance.AddItemToStorage(testItem, 1);
-        Debug.Log($"{testItem.name}창고에 추가됨");
+        if (Input.GetKeyDown(KeyCode.H))
+        {
+
+            Storage.Instance.AddItemToStorage(testItem, 1);
+            Debug.Log($"{testItem.name}창고에 추가됨");
+        }
         //**테스트용 코드 반드시 삭제**
     }
 
@@ -91,31 +97,38 @@ public class EventManager : MonoBehaviour
 
     public void EventStart() // 일자가 시작될때 호출.
     {
-        ButtonClear();
         GenerateDailyEvent();
         GenerateRandomEvent();
-        FinishedButtonInstantiate();
+        DettachButton();
+        AttachButton(CurEventButtons);
+        AttachButton(FinishedButtons);
     }
 
-    public void ButtonClear()
+    public void DettachButton()
     {
         for (int i = 0; i < eventContents.childCount; i++)
         {
-            Destroy(eventContents.GetChild(i));
+            eventContents.DetachChildren();
         }
-
     }
-
-    public void FinishedButtonInstantiate()
+    public void AttachButton(List<Button> list)
     {
-        foreach (Button bt in FinishedButtons)
+        for (int i = 0; i < list.Count; i++)
         {
-            Instantiate(bt).gameObject.transform.SetParent(eventContents);
-            bt.interactable = false;
-        }
+            list[i].transform.SetParent(eventContents);
+            int temp = i; //??
+            if(list == CurEventButtons)
+            {
+                list[i].onClick.RemoveAllListeners();
+                list[i].onClick.AddListener(() => eventUI.SetEventListTitleText(CurEvents[temp], temp)); //0704 
+                
+            }
 
+        }
     }
-    public void GenerateDailyEvent() //아침시점에 호출되어야 함
+    
+
+    public void GenerateDailyEvent() 
     {
         //중복발생불가 로직이 필요한가?
         CurEvents.Add(eventDict[10001]);
@@ -128,16 +141,10 @@ public class EventManager : MonoBehaviour
     public void EventButtonCreate(int eventIndex)
     {
         CurEventButtons.Add(Instantiate(eventButtonPrefab));
-        CurEventButtons[eventIndex].transform.SetParent(eventContents);
         eventUI.SetEventSubUIBtnTitle(CurEventButtons[eventIndex].gameObject, eventIndex); //추가한부분**서브타이틀용**
-
-
-
-        CurEventButtons[eventIndex].onClick
-            .AddListener(() => eventUI.SetEventListTitleText(CurEvents[eventIndex], eventIndex));
     }
 
-    public void GenerateRandomEvent() // ******아침시점에 호출되어야함 씬변경관련시스템살펴보기 
+    public void GenerateRandomEvent() 
     {
         int eventID = 0;
         if (3 >= StatusSystem.Instance.GetCurrentDay())
@@ -172,7 +179,7 @@ public class EventManager : MonoBehaviour
     }
 
     // 이벤트가 완료가능인지 판별
-    public bool DetermineEventComplete(GameEventData data) //*버튼에 호출 달아줘야함
+    public bool DetermineEventComplete(GameEventData data) 
     {
         if (data.requiredItemA != null && data.requiredItemB == null)
             return data.requiredAmountA <= Storage.Instance.GetItemCount(data.requiredItemA);
@@ -183,7 +190,7 @@ public class EventManager : MonoBehaviour
         return false;
     }
 
-    public void EventEffect(GameEventData data) //******날짜가 넘어갈때 적용되어야함 이함수가 어디선가 호출되어야 함 => 날짜넘어가는시스템쪽 확인해서 집어넣기
+    public void EventEffect(GameEventData data) 
     {
         if (data.isComplete)
         {
@@ -211,5 +218,27 @@ public class EventManager : MonoBehaviour
         FinishedButtons.Add(CurEventButtons[eventIndex]);
         CurEvents.RemoveAt(eventIndex);
         CurEventButtons.RemoveAt(eventIndex);
+
+        DettachButton();
+        AttachButton(CurEventButtons);
+        AttachButton(FinishedButtons);
+
+        //Storage.Instance.RemoveItem(data.requiredItemA, data.requiredAmountA);
+        //if (data.requiredItemB != null)
+        //    Storage.Instance.RemoveItem(data.requiredItemB, data.requiredAmountB);
+        //CurEventButtons[eventIndex].interactable = false;
+        //FinishedButtons.Add(CurEventButtons[eventIndex]);
+        //CurEvents.RemoveAt(eventIndex);
+
+        //CurEventButtons[eventIndex].transform.SetParent(eventContents); //추가
+
+        //CurEventButtons.RemoveAt(eventIndex);
+
+
+
+
+        //ButtonClear(); //0704 추가
+        //EventButtonInstantiate();//0704 추가
+        //FinishedButtonInstantiate();//0704 추가
     }
 }

--- a/Assets/WorkPlace/LHG/Scripts/EventSystem/EventUI.cs
+++ b/Assets/WorkPlace/LHG/Scripts/EventSystem/EventUI.cs
@@ -34,6 +34,7 @@ public class EventUI : MonoBehaviour
         EventClearDetermine(data);
         CanCompleteBtns.onClick.AddListener(() => EventClearOnUI(data));
         eventIndex = _eventIndex;
+        Completed.gameObject.SetActive(false); //0704완료됨버튼관련 비활성화조치
     }
 
 
@@ -54,6 +55,7 @@ public class EventUI : MonoBehaviour
 
     public void EventClearOnUI(GameEventData data)
     {
+        CanCompleteBtns.gameObject.SetActive(false);//0704완료가능버튼관련 비활성화조치
         Completed.gameObject.SetActive(true);
         data.isComplete = true;
         EventManager.Instance.EventClear(data, eventIndex);

--- a/Assets/WorkPlace/LHG/Scripts/ShelterUI.cs
+++ b/Assets/WorkPlace/LHG/Scripts/ShelterUI.cs
@@ -74,10 +74,36 @@ public class ShelterUI : MonoBehaviour
     public void ActiveUI(int ShelterMenuID)
     {
         ShelterMenu[ShelterMenuID].SetActive(true);
-        Debug.Log($"{ShelterMenuID.ToString()} UI Active");
+        Debug.Log($"{ShelterMenuID} UI Active");
 
-        //EventCompleteBtnSwitcher(testState);
+        switch (ShelterMenuID)
+        {
+            case 0: // 모니터 → 이벤트 탭
+                SwitchToTab(0); // 탭 전환
+                AutoSelectFirstEvent(); // 제일 위 이벤트 자동 선택
+                break;
+            case 1: // 워크벤치 → 제작 탭
+                SwitchToTab(2); // 탭 전환
+                                // TODO: 제작 탭 초기화 코드 추가 예정
+                break;
+            case 2: // 맵 → 맵 탭 + 쉘터 자동 선택
+                SwitchToTab(1);
+                SelectMapList(1); // 쉘터 선택 (0:침실, 1:쉘터, 2:출구)
+                break;
+        }
     }
+
+    private void AutoSelectFirstEvent()
+    {
+        if (EventManager.Instance.CurEvents.Count > 0)
+        {
+            var firstEvent = EventManager.Instance.CurEvents[0];
+            var eventUI = FindObjectOfType<EventUI>(); // 참조 방식에 따라 수정
+            eventUI.SetEventListTitleText(firstEvent, 0); // 첫 번째 이벤트 출력
+        }
+    }
+
+
     public void DeactiveUI(int ShelterMenuID)
     {
         ShelterMenu[ShelterMenuID].SetActive(false);

--- a/Assets/WorkPlace/LHG/Scripts/ShelterUI.cs
+++ b/Assets/WorkPlace/LHG/Scripts/ShelterUI.cs
@@ -19,22 +19,45 @@ public class ShelterUI : MonoBehaviour
     [SerializeField] public TMP_Text[] Indicators, TonightEventText;
     public Image[] TabButtons, MapLocationsButtons;
     public Sprite InactiveTabBG, ActiveTabBG; // 활성 비활성 시각화를 백그라운드스프라이트로 처리할 때 필요
-    
-    //[SerializeField] private EventState testState; //TODO 이벤트마다 스테이트를 가져야함, 충족시 해당 이벤트의 스테이트를 변경해주도록 만들어야
 
-    // 250628 빌드 오류
-    // [SerializeField] private double testOxygen = StatusSystem.Instance.GetOxygen();
-    [SerializeField] private double testOxygen;
+
+    //0704 실시간으로 인디케이터에 수치를 반영하기 위한 변수
+    private double prevOxygen;
+    private double prevEnergy;
+    private double prevDurability;
+
+
 
     public GameObject Renpy;
     
     private void Start()
     {
         DisplayIndicators(0);
-        //시스템캔버스 false로 일단 
 
+        // 초기 값 캐싱
+        prevOxygen = StatusSystem.Instance.GetOxygen();
+        prevEnergy = StatusSystem.Instance.GetEnergy();
+        prevDurability = StatusSystem.Instance.GetDurability();
     }
-    
+
+    private void Update()
+    {
+        double curOxygen = StatusSystem.Instance.GetOxygen();
+        double curEnergy = StatusSystem.Instance.GetEnergy();
+        double curDurability = StatusSystem.Instance.GetDurability();
+
+        // 값이 변경되었을 때만 UI 갱신
+        if (!Mathf.Approximately((float)prevOxygen, (float)curOxygen) ||
+            !Mathf.Approximately((float)prevEnergy, (float)curEnergy) ||
+            !Mathf.Approximately((float)prevDurability, (float)curDurability))
+        {
+            DisplayIndicators(0);
+            prevOxygen = curOxygen;
+            prevEnergy = curEnergy;
+            prevDurability = curDurability;
+        }
+    }
+
     public void DisplayIndicators(int indicatorsID)
     {
         //[패널상단] 0:날짜 1:산소 / [패널]-[맵]-[쉘터]-[subUI] 2:산소, 3:전력(Energy/Electricity 용어통일필요?), 4:내구도

--- a/Assets/WorkPlace/LHG/Scripts/ShelterUI.cs
+++ b/Assets/WorkPlace/LHG/Scripts/ShelterUI.cs
@@ -15,12 +15,12 @@ public class ShelterUI : MonoBehaviour
     [SerializeField] public GameObject SystemCanvas;
 
 
-    public GameObject[] ShelterMenu, Tabs, EventContainer, CompleteBtn, MapLocations, ExitShelterCases;
+    public GameObject[] ShelterMenu, Tabs, EventContainer, MapLocations, ExitShelterCases;
     [SerializeField] public TMP_Text[] Indicators, TonightEventText;
     public Image[] TabButtons, MapLocationsButtons;
     public Sprite InactiveTabBG, ActiveTabBG; // 활성 비활성 시각화를 백그라운드스프라이트로 처리할 때 필요
     
-    [SerializeField] private EventState testState; //TODO 이벤트마다 스테이트를 가져야함, 충족시 해당 이벤트의 스테이트를 변경해주도록 만들어야
+    //[SerializeField] private EventState testState; //TODO 이벤트마다 스테이트를 가져야함, 충족시 해당 이벤트의 스테이트를 변경해주도록 만들어야
 
     // 250628 빌드 오류
     // [SerializeField] private double testOxygen = StatusSystem.Instance.GetOxygen();
@@ -53,7 +53,7 @@ public class ShelterUI : MonoBehaviour
         ShelterMenu[ShelterMenuID].SetActive(true);
         Debug.Log($"{ShelterMenuID.ToString()} UI Active");
 
-        EventCompleteBtnSwitcher(testState);
+        //EventCompleteBtnSwitcher(testState);
     }
     public void DeactiveUI(int ShelterMenuID)
     {
@@ -73,7 +73,7 @@ public class ShelterUI : MonoBehaviour
         //Tabs [패널탭] 0:이벤트, 1:맵, 2:제작
         //TabButtons(이미지변경용엘리먼트) [패널탭] 0:이벤트, 1:맵, 2:제작 
 
-        EventCompleteBtnSwitcher(testState);
+        //EventCompleteBtnSwitcher(testState);
 
         foreach (GameObject go in Tabs)
         {
@@ -186,41 +186,41 @@ public class ShelterUI : MonoBehaviour
     }
 
 
-    public void EventCompleteBtnSwitcher(EventState state)
-    {
-        //버튼엘리먼트 0:완료불가, 1:완료가능, 2:완료됨
-        foreach (GameObject go in CompleteBtn)
-        {
-            go.SetActive(false); //일단 비활성화 초기화 후,
-        }
+    //public void EventCompleteBtnSwitcher(EventState state)
+    //{
+    //    //버튼엘리먼트 0:완료불가, 1:완료가능, 2:완료됨
+    //    foreach (GameObject go in CompleteBtn)
+    //    {
+    //        go.SetActive(false); //일단 비활성화 초기화 후,
+    //    }
 
-        CompleteBtn[(int)state].SetActive(true); // 배열에담긴버튼과 상태에 따라 액티브
-    }
+    //    CompleteBtn[(int)state].SetActive(true); // 배열에담긴버튼과 상태에 따라 액티브
+    //}
 
-    public void EventCompleteBtn(int CompleteBtnID)
-    {
-        //TODO 이벤트매니저에서 이벤트완료시 처리되는 함수를 호출 = 종료효과 등
+    //public void EventCompleteBtn(int CompleteBtnID)
+    //{
+    //    //TODO 이벤트매니저에서 이벤트완료시 처리되는 함수를 호출 = 종료효과 등
 
-        foreach(GameObject go in CompleteBtn)
-        {
-            //기존버튼을 비활성화 후
-            go.SetActive(false);
-            //완료됨 버튼을 활성화
-            CompleteBtn[2].SetActive(true);
-        }
+    //    foreach(GameObject go in CompleteBtn)
+    //    {
+    //        //기존버튼을 비활성화 후
+    //        go.SetActive(false);
+    //        //완료됨 버튼을 활성화
+    //        CompleteBtn[2].SetActive(true);
+    //    }
         
-        //TODO 이벤트매니저에 이벤트의 상태를 완료됨으로 변경.
-        //TODO 이벤트 리스트 버튼을 회색처리해주고 정렬을 밑으로...
-    }
+    //    //TODO 이벤트매니저에 이벤트의 상태를 완료됨으로 변경.
+    //    //TODO 이벤트 리스트 버튼을 회색처리해주고 정렬을 밑으로...
+    //}
 
-    //완료,완료불가,완료됨 버튼의 상태 열거형
-    public enum EventState
-    {
-        //상태 변수명 나중에 다시 통일
-        CanNotComplete,
-        CanComplete,
-        AlreadyComplted
-    }
+    ////완료,완료불가,완료됨 버튼의 상태 열거형
+    //public enum EventState
+    //{
+    //    //상태 변수명 나중에 다시 통일
+    //    CanNotComplete,
+    //    CanComplete,
+    //    AlreadyComplted
+    //}
 
     private void TonightEventDisplay()
     {

--- a/Assets/WorkPlace/LHG/Scripts/StatusIndicatorWatcher_notuse.cs
+++ b/Assets/WorkPlace/LHG/Scripts/StatusIndicatorWatcher_notuse.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+public class StatusWatcher : MonoBehaviour
+{
+    private double _prevOxygen;
+    private double _prevEnergy;
+    private double _prevDurability;
+
+    [SerializeField] private ShelterUI shelterUI;
+
+    private void Start()
+    {
+        _prevOxygen = StatusSystem.Instance.GetOxygen();
+        _prevEnergy = StatusSystem.Instance.GetEnergy();
+        _prevDurability = StatusSystem.Instance.GetDurability();
+
+        if (shelterUI == null)
+        {
+            shelterUI = FindObjectOfType<ShelterUI>();
+        }
+    }
+
+    private void Update()
+    {
+        double curOxygen = StatusSystem.Instance.GetOxygen();
+        double curEnergy = StatusSystem.Instance.GetEnergy();
+        double curDurability = StatusSystem.Instance.GetDurability();
+
+        if (!Mathf.Approximately((float)curOxygen, (float)_prevOxygen) ||
+            !Mathf.Approximately((float)curEnergy, (float)_prevEnergy) ||
+            !Mathf.Approximately((float)curDurability, (float)_prevDurability))
+        {
+            shelterUI.DisplayIndicators(0);
+        }
+
+        _prevOxygen = curOxygen;
+        _prevEnergy = curEnergy;
+        _prevDurability = curDurability;
+    }
+}

--- a/Assets/WorkPlace/LHG/Scripts/StatusIndicatorWatcher_notuse.cs.meta
+++ b/Assets/WorkPlace/LHG/Scripts/StatusIndicatorWatcher_notuse.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cbc5f0ff67780a40b6dc46fdbade306
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
서브ui 이벤트리스트가 완료된 이벤트는 비활성화 처리 및, 리스트의 아래로 정렬됨
메인ui에서 완료,완료됨,완료불가 버튼을 작동하도록 함

쉘터씬의 인디케이터 요소들을 실시간으로 반영하도록
메시지함수 업데이트를 통해 구현

active ui 를 구체화해서
각 모니터, 맵, 작업대를 눌렀을 때 해당 탭이 선택된 상태로 ui를 출력
+가장 첫이벤트가 선택된 상태로 + 쉘터가 선택된 상태로 출력